### PR TITLE
Remove nonce granulation to 1 second - fix issue #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ Cryptopia.prototype.pubRequest = function(method, params, callback) {
 };
 
 Cryptopia.prototype.privateRequest = function(method, params, callback) {
-	var nonce = Math.floor(new Date().getTime() / 1000);
+	var nonce = Math.floor(new Date().getTime());
 	var md5 = crypto.createHash('md5').update( JSON.stringify( params ) ).digest();
 	var requestContentBase64String = md5.toString('base64');
 	var signature = this.key + "POST" + encodeURIComponent( this.baseURL + "/" + method).toLowerCase() + nonce + requestContentBase64String;


### PR DESCRIPTION
Fix API error "once has already been used for this request." on high frequency requests.